### PR TITLE
chore: deprecate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> ⚠️ This package is deprecated as of [`vite-tsconfig-paths` v3.5](https://github.com/aleclarson/vite-tsconfig-paths/releases/tag/v3.5.0). ⚠️
+
 # vite-jsconfig-paths
 
 [![npm](https://img.shields.io/npm/v/vite-jsconfig-paths.svg)](https://www.npmjs.com/package/vite-jsconfig-paths)


### PR DESCRIPTION
`vite-tsconfig-paths` now supports `jsconfig.json` files as well.

https://github.com/aleclarson/vite-tsconfig-paths/pull/57
https://github.com/aleclarson/vite-tsconfig-paths/releases/tag/v3.5.0